### PR TITLE
Maven plug-in enhance to permit pattern-based permissions in configuration.

### DIFF
--- a/iso9660-maven-plugin/pom.xml
+++ b/iso9660-maven-plugin/pom.xml
@@ -37,10 +37,10 @@
             <version>3.0.4</version>
         </dependency>
         <dependency>
-			<groupId>org.apache.maven</groupId>
-			<artifactId>maven-archiver</artifactId>
-			<version>2.5</version>
-		</dependency>
+            <groupId>org.apache.maven</groupId>
+            <artifactId>maven-archiver</artifactId>
+            <version>2.5</version>
+        </dependency>
         <dependency>
             <groupId>com.github.stephenc.java-iso-tools</groupId>
             <artifactId>iso9660-writer</artifactId>
@@ -51,16 +51,16 @@
             <artifactId>plexus-utils</artifactId>
             <version>2.0.5</version>
         </dependency>
-		<dependency>
-			<groupId>org.codehaus.plexus</groupId>
-			<artifactId>plexus-archiver</artifactId>
-			<version>2.1.1</version>
-		</dependency>
-		<dependency>
-			<groupId>org.codehaus.plexus</groupId>
-			<artifactId>plexus-component-annotations</artifactId>
-			<version>1.5.5</version>
-		</dependency>
+        <dependency>
+            <groupId>org.codehaus.plexus</groupId>
+            <artifactId>plexus-archiver</artifactId>
+            <version>2.1.1</version>
+        </dependency>
+        <dependency>
+            <groupId>org.codehaus.plexus</groupId>
+            <artifactId>plexus-component-annotations</artifactId>
+            <version>1.5.5</version>
+        </dependency>
         <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>

--- a/iso9660-maven-plugin/src/main/java/com/github/stephenc/javaisotools/maven/FilePermission.java
+++ b/iso9660-maven-plugin/src/main/java/com/github/stephenc/javaisotools/maven/FilePermission.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright (c) 2013 Brad BARCLAY. <brad.barclay@infor.com>
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+ */
+
+package com.github.stephenc.javaisotools.maven;
+
+/**
+ *
+ * @author yaztromo
+ */
+public class FilePermission {
+    public String filePattern;
+    public String permission;
+
+    public String getFilePattern() {
+        return filePattern;
+    }
+
+    public void setFilePattern(String filePattern) {
+        this.filePattern = filePattern;
+    }
+
+    public String getPermission() {
+        return permission;
+    }
+
+    public void setPermission(String permission) {
+        this.permission = permission;
+    }
+    
+    public int getPermissionAsInt() throws NumberFormatException {
+        return Integer.decode(permission);
+    }
+}

--- a/iso9660-maven-plugin/src/main/resources/META-INF/plexus/components.xml
+++ b/iso9660-maven-plugin/src/main/resources/META-INF/plexus/components.xml
@@ -33,14 +33,14 @@
             </configuration>
         </component>
         <component>
-			<role>org.codehaus.plexus.archiver.Archiver</role>
-			<role-hint>iso</role-hint>
-			<implementation>com.github.stephenc.javaisotools.maven.Iso9660Archiver</implementation>
-			<configuration>
-				<type>iso</type>
-				<extension>iso</extension>
-			</configuration>
-			<instantiation-strategy>per-lookup</instantiation-strategy>
-		</component>
+            <role>org.codehaus.plexus.archiver.Archiver</role>
+            <role-hint>iso</role-hint>
+            <implementation>com.github.stephenc.javaisotools.maven.Iso9660Archiver</implementation>
+            <configuration>
+                <type>iso</type>
+                <extension>iso</extension>
+            </configuration>
+            <instantiation-strategy>per-lookup</instantiation-strategy>
+        </component>
     </components>
 </component-set>

--- a/iso9660-writer/src/main/java/com/github/stephenc/javaisotools/iso9660/StandardConfig.java
+++ b/iso9660-writer/src/main/java/com/github/stephenc/javaisotools/iso9660/StandardConfig.java
@@ -23,7 +23,6 @@ import java.io.File;
 import java.util.ArrayList;
 import java.util.Date;
 import java.util.List;
-import java.util.Vector;
 
 import com.github.stephenc.javaisotools.sabre.HandlerException;
 
@@ -283,7 +282,7 @@ public abstract class StandardConfig {
     /**
      * Set Data Preparer
      *
-     * @param dataPreparer File containting information on the volume data preparer
+     * @param dataPreparer File containing information on the volume data preparer
      *
      * @throws HandlerException Problems converting to ISO9660File
      */
@@ -382,7 +381,7 @@ public abstract class StandardConfig {
     /**
      * Returns active System Identifier
      *
-     * @return Active System Identifer
+     * @return Active System Identifier
      */
     public String getSystemID() {
         return systemID;

--- a/iso9660-writer/src/main/java/com/github/stephenc/javaisotools/iso9660/impl/ISO9660Handler.java
+++ b/iso9660-writer/src/main/java/com/github/stephenc/javaisotools/iso9660/impl/ISO9660Handler.java
@@ -1,4 +1,5 @@
 /*
+ * Copyright (c) 2013. Brad BARCLAY <brad.barclay@infor.com>
  * Copyright (c) 2010. Stephen Connolly.
  * Copyright (C) 2007. Jens Hatlak <hatlak@rbg.informatik.tu-darmstadt.de>
  *
@@ -56,7 +57,7 @@ public class ISO9660Handler extends StandardHandler {
         this.helper = new ISO9660LayoutHelper(this, isoRoot);
 
         if (rrConfig != null) {
-            this.factory = new ISO9660RockRidgeFactory(this, config, helper, root, isoRoot, volumeFixups);
+            this.factory = new ISO9660RockRidgeFactory(this, config, helper, root, isoRoot, volumeFixups, rrConfig.getPatternToModeMap());
         } else {
             this.factory = new ISO9660Factory(this, config, helper, isoRoot, volumeFixups);
         }

--- a/iso9660-writer/src/main/java/com/github/stephenc/javaisotools/iso9660/impl/ISO9660RockRidgeFactory.java
+++ b/iso9660-writer/src/main/java/com/github/stephenc/javaisotools/iso9660/impl/ISO9660RockRidgeFactory.java
@@ -417,13 +417,10 @@ public class ISO9660RockRidgeFactory extends ISO9660Factory {
         final POSIXFileMode ret = new POSIXFileMode();
         
         // Try to see if we can match the object name against one of the matchers
-        System.out.println(String.format("*** Checking permissions map for file with name \"%s\".", ho.getName()));
         for(String pattern:fileModesMap.keySet()) {
-            System.out.println(String.format("*** Comparing to pattern \"%s\"", pattern));
             Pattern p = Pattern.compile(pattern, Pattern.CASE_INSENSITIVE);
             Matcher m = p.matcher(ho.getName());
             if (m.matches()) {
-                System.out.println(String.format("*** Matched object with name \"%s\".  Applying permission %o.", ho.getName(), fileModesMap.get(pattern)));
                 POSIXFileMode mode = new POSIXFileMode();
                 mode.setDefault(ho instanceof ISO9660Directory);
                 mode.setPermission(fileModesMap.get(pattern));

--- a/iso9660-writer/src/main/java/com/github/stephenc/javaisotools/iso9660/impl/ISO9660RockRidgeFactory.java
+++ b/iso9660-writer/src/main/java/com/github/stephenc/javaisotools/iso9660/impl/ISO9660RockRidgeFactory.java
@@ -1,4 +1,5 @@
 /*
+ * Copyright (c) 2013. Brad BARCLAY <brad.barclay@infor.com>
  * Copyright (c) 2010. Stephen Connolly.
  * Copyright (C) 2007. Jens Hatlak <hatlak@rbg.informatik.tu-darmstadt.de>
  *
@@ -19,17 +20,11 @@
 
 package com.github.stephenc.javaisotools.iso9660.impl;
 
+import com.github.stephenc.javaisotools.iso9660.*;
 import java.util.HashMap;
 import java.util.Iterator;
 import java.util.LinkedList;
 
-import com.github.stephenc.javaisotools.iso9660.FilenameDataReference;
-import com.github.stephenc.javaisotools.iso9660.ISO9660Directory;
-import com.github.stephenc.javaisotools.iso9660.ISO9660File;
-import com.github.stephenc.javaisotools.iso9660.ISO9660RootDirectory;
-import com.github.stephenc.javaisotools.iso9660.LayoutHelper;
-import com.github.stephenc.javaisotools.iso9660.NamingConventions;
-import com.github.stephenc.javaisotools.iso9660.StandardConfig;
 import com.github.stephenc.javaisotools.iso9660.sabre.impl.BothWordDataReference;
 import com.github.stephenc.javaisotools.rockridge.impl.POSIXFileMode;
 import com.github.stephenc.javaisotools.rockridge.impl.RRIPFactory;
@@ -39,6 +34,9 @@ import com.github.stephenc.javaisotools.sabre.HandlerException;
 import com.github.stephenc.javaisotools.rockridge.impl.RockRidgeLayoutHelper;
 import com.github.stephenc.javaisotools.rockridge.impl.RockRidgeNamingConventions;
 import com.github.stephenc.javaisotools.sabre.StreamHandler;
+import java.util.Map;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
 public class ISO9660RockRidgeFactory extends ISO9660Factory {
 
@@ -47,9 +45,10 @@ public class ISO9660RockRidgeFactory extends ISO9660Factory {
     private RockRidgeLayoutHelper helper;
     private ISO9660RootDirectory rripRoot;
     private HashMap originalParentMapper, parentLocationFixups, parentLocations, childLocationFixups, childLocations;
+    private final Map<String, Integer> fileModesMap;
 
     public ISO9660RockRidgeFactory(StreamHandler streamHandler, StandardConfig config, LayoutHelper helper,
-                                   ISO9660RootDirectory root, ISO9660RootDirectory isoRoot, HashMap volumeFixups) {
+                                   ISO9660RootDirectory root, ISO9660RootDirectory isoRoot, HashMap volumeFixups, Map<String, Integer> fileModesMap) {
         super(streamHandler, config, helper, isoRoot, volumeFixups);
         this.rripFactory = new RRIPFactory(streamHandler);
         this.unfinishedNMEntries = new LinkedList();
@@ -59,6 +58,7 @@ public class ISO9660RockRidgeFactory extends ISO9660Factory {
         this.helper = new RockRidgeLayoutHelper(streamHandler, isoRoot, rripRoot);
 
         originalParentMapper = new HashMap();
+        this.fileModesMap = fileModesMap;
     }
 
     public void applyNamingConventions() throws HandlerException {
@@ -139,9 +139,7 @@ public class ISO9660RockRidgeFactory extends ISO9660Factory {
         }
 
         // PX: POSIX File Attributes
-        POSIXFileMode fileMode = new POSIXFileMode();
-        fileMode.setDefault(true);
-        int fileModes = fileMode.getFileMode();
+        int fileModes = getPOSIXFileModeForObject(dir).getFileMode();
         int fileLinks = 2 + dir.getDirectories().size();
         rripFactory.doPXEntry(fileModes, fileLinks, 0, 0, 1);
 
@@ -169,8 +167,7 @@ public class ISO9660RockRidgeFactory extends ISO9660Factory {
         }
 
         // PX: POSIX File Attributes
-        POSIXFileMode fileMode = new POSIXFileMode();
-        fileMode.setDefault(false);
+        POSIXFileMode fileMode = getPOSIXFileModeForObject(file);
         int fileModes = fileMode.getFileMode();
         rripFactory.doPXEntry(fileModes, 1, 0, 0, 1);
 
@@ -207,8 +204,7 @@ public class ISO9660RockRidgeFactory extends ISO9660Factory {
         }
 
         // PX: POSIX File Attributes
-        POSIXFileMode fileMode = new POSIXFileMode();
-        fileMode.setDefault(true);
+        POSIXFileMode fileMode = getPOSIXFileModeForObject(dir);
         int fileModes = fileMode.getFileMode();
         int fileLinks = 2 + dir.getDirectories().size();
         rripFactory.doPXEntry(fileModes, fileLinks, 0, 0, 1);
@@ -243,8 +239,7 @@ public class ISO9660RockRidgeFactory extends ISO9660Factory {
         }
 
         // PX: POSIX File Attributes
-        POSIXFileMode fileMode = new POSIXFileMode();
-        fileMode.setDefault(true);
+        POSIXFileMode fileMode = getPOSIXFileModeForObject(dir);
         int fileModes = fileMode.getFileMode();
         int fileLinks = 2 + dir.getDirectories().size();
         rripFactory.doPXEntry(fileModes, fileLinks, 0, 0, 1);
@@ -289,8 +284,7 @@ public class ISO9660RockRidgeFactory extends ISO9660Factory {
         }
 
         // PX: POSIX File Attributes
-        POSIXFileMode fileMode = new POSIXFileMode();
-        fileMode.setDefault(true);
+        POSIXFileMode fileMode = getPOSIXFileModeForObject(dir);
         int fileModes = fileMode.getFileMode();
         int fileLinks = 2 + parentDir.getDirectories().size();
         rripFactory.doPXEntry(fileModes, fileLinks, 0, 0, 1);
@@ -419,6 +413,29 @@ public class ISO9660RockRidgeFactory extends ISO9660Factory {
         streamHandler.endElement();
     }
 
+    private POSIXFileMode getPOSIXFileModeForObject(ISO9660HierarchyObject ho) {
+        final POSIXFileMode ret = new POSIXFileMode();
+        
+        // Try to see if we can match the object name against one of the matchers
+        System.out.println(String.format("*** Checking permissions map for file with name \"%s\".", ho.getName()));
+        for(String pattern:fileModesMap.keySet()) {
+            System.out.println(String.format("*** Comparing to pattern \"%s\"", pattern));
+            Pattern p = Pattern.compile(pattern, Pattern.CASE_INSENSITIVE);
+            Matcher m = p.matcher(ho.getName());
+            if (m.matches()) {
+                System.out.println(String.format("*** Matched object with name \"%s\".  Applying permission %o.", ho.getName(), fileModesMap.get(pattern)));
+                POSIXFileMode mode = new POSIXFileMode();
+                mode.setDefault(ho instanceof ISO9660Directory);
+                mode.setPermission(fileModesMap.get(pattern));
+                return mode;
+            }
+        }
+        
+        // If not, return the default mode object
+        ret.setDefault(ho instanceof ISO9660Directory);
+        return ret;
+    }
+    
     class UnfinishedNMEntry {
 
         Fixup location, offset, length;

--- a/iso9660-writer/src/main/java/com/github/stephenc/javaisotools/rockridge/impl/RockRidgeConfig.java
+++ b/iso9660-writer/src/main/java/com/github/stephenc/javaisotools/rockridge/impl/RockRidgeConfig.java
@@ -1,4 +1,5 @@
 /*
+ * Copyright (c) 2013. Brad BARCLAY <brad.barclay@infor.com>
  * Copyright (c) 2010. Stephen Connolly.
  * Copyright (C) 2007. Jens Hatlak <hatlak@rbg.informatik.tu-darmstadt.de>
  *
@@ -20,9 +21,14 @@
 package com.github.stephenc.javaisotools.rockridge.impl;
 
 import com.github.stephenc.javaisotools.iso9660.ConfigException;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
 
 public class RockRidgeConfig {
 
+    private Map<String, Integer> patternToModeMap = new HashMap<String, Integer>();
+    
     /**
      * Set mkisofs Compatibility<br> mkisofs implements version 1.09 of the Rock Ridge Interchange Protocol, whereas the
      * current version 1.12 was adopted as an IEEE standard. The differences are as follows:<br> 1. The ER System Use
@@ -79,5 +85,23 @@ public class RockRidgeConfig {
      */
     public void hideMovedDirectoriesStore(boolean flag) {
         RockRidgeNamingConventions.HIDE_MOVED_DIRECTORIES_STORE = flag;
+    }
+
+    /**
+     * Add a new mode for a specific file pattern.
+     * @param pattern the pattern to be matched
+     * @param mode the POSIX file mode for matching filenames
+     */
+    public void addModeForPattern(String pattern, Integer mode) {
+        System.out.println(String.format("*** Recording pattern \"%s\" with mode %o", pattern, mode));
+        patternToModeMap.put(pattern, mode);
+    }
+
+    /**
+     * Retrieve the pattern-to-mode map in an unmodifiable form.
+     * @return the pattern-to-mode map in an unmodifiable form.
+     */
+    public Map<String, Integer> getPatternToModeMap() {
+        return Collections.unmodifiableMap(patternToModeMap);
     }
 }

--- a/pom.xml
+++ b/pom.xml
@@ -67,7 +67,11 @@
             <id>stephenc</id>
             <name>Stephen Connolly</name>
         </developer>
-    </developers>
+            <developer>
+                <id>yaztromo</id>
+                <name>Brad BARCLAY</name>
+            </developer>
+        </developers>
 
     <build>
         <pluginManagement>


### PR DESCRIPTION
Modifications to permit the Maven plug-in to allow pattern-based configuration for setting permissions on files when writing the Rock Ridge extensions (useful for setting +x to files based on patterns).

The configuration block section for this support looks like this:

                        <configuration>
                            <permissions>
                                <filePermission>
                                    <filePattern>.*\.sh</filePattern>
                                    <permission>0555</permission>
                                </filePermission>
                                <filePermission>
                                	<filePattern>.*\.p(y|l)</filePattern>
                                	<permission>0555</permission>
                                </filePermission>
                            </permissions>
                        </configuration>

This will ensure all that *.sh, *.py, and *.pl files get ugo+rx permissions during ISO generation.

(Also includes a small number of style fixes where there were indentation mismatches, and a few typos in comments).