### PR TITLE
updated apache ant and maven-compiler-plugin

### DIFF
--- a/iso9660-ant-tasks/pom.xml
+++ b/iso9660-ant-tasks/pom.xml
@@ -31,7 +31,7 @@
         <dependency>
             <groupId>org.apache.ant</groupId>
             <artifactId>ant</artifactId>
-            <version>1.7.1</version>
+            <version>1.9.15</version>
             <scope>provided</scope>
         </dependency>
         <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -85,8 +85,8 @@
                     <artifactId>maven-compiler-plugin</artifactId>
                     <version>3.3</version>
                     <configuration>
-                        <source>1.5</source>
-                        <target>1.5</target>
+                        <source>1.7</source>
+                        <target>1.7</target>
                     </configuration>
                 </plugin>
                 <plugin>

--- a/sabre/pom.xml
+++ b/sabre/pom.xml
@@ -55,7 +55,7 @@
         <dependency>
             <groupId>org.apache.ant</groupId>
             <artifactId>ant</artifactId>
-            <version>1.7.1</version>
+            <version>1.9.15</version>
         </dependency>     
     </dependencies>
 


### PR DESCRIPTION
Hello, 

Just wanted to update the apache ant lib due to the following issue: 

https://cve.mitre.org/cgi-bin/cvename.cgi?name=2020-1945

The issue was resolved in ant v1.9.15 (see https://ant.apache.org/)

Also, received errors that the maven-compiler-plugin is outdated so I updated that to v1.7 
